### PR TITLE
Fix Sci-Hub MCP search/download reliability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ requests>=2.31.0
 bs4>=0.0.1
 mcp>=0.1.0
 scihub
-
+curl-cffi>=0.14.0

--- a/sci_hub_search.py
+++ b/sci_hub_search.py
@@ -1,136 +1,595 @@
-from scihub import SciHub
-import re
+import logging
 import os
-import urllib3
-import requests
+import re
+from urllib.parse import unquote, urljoin, urlparse
 
-# 禁用 HTTPS 证书验证警告
+import requests
+import urllib3
+from bs4 import BeautifulSoup
+from scihub import SciHub
+
+try:
+    from curl_cffi import requests as curl_requests
+except Exception:  # pragma: no cover - optional dependency
+    curl_requests = None
+
+# Disable HTTPS certificate verification warnings because some mirrors use broken TLS chains.
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-def create_scihub_instance():
-    """创建 SciHub 实例并配置"""
-    sh = SciHub()
-    sh.timeout = 30  # 增加超时时间到 30 秒
-    return sh
+DEFAULT_SCIHUB_BASE_URL = "https://sci-hub.ren"
+DEFAULT_TIMEOUT_SECONDS = 20.0
+DEFAULT_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/124.0.0.0 Safari/537.36"
+)
 
-def search_paper_by_doi(doi):
-    """通过 DOI 在 Sci-Hub 上搜索论文"""
-    sh = create_scihub_instance()
+LOGGER = logging.getLogger(__name__)
+logging.getLogger("scihub").setLevel(logging.ERROR)
+
+
+def _get_http_client_name():
+    requested = os.getenv("SCIHUB_HTTP_CLIENT", "").strip().lower()
+    if requested in {"curl_cffi", "requests"}:
+        if requested == "curl_cffi" and curl_requests is None:
+            LOGGER.warning("SCIHUB_HTTP_CLIENT=curl_cffi requested but curl_cffi is not installed. Falling back to requests.")
+            return "requests"
+        return requested
+
+    if requested:
+        LOGGER.warning("Unknown SCIHUB_HTTP_CLIENT=%r. Falling back to auto selection.", requested)
+    return "curl_cffi" if curl_requests is not None else "requests"
+
+
+def _normalize_mirror(value):
+    """Convert mirror URL/host input to host format."""
+    raw = (value or "").strip()
+    if not raw:
+        return ""
+
+    parsed = urlparse(raw if "://" in raw else f"https://{raw}")
+    host = (parsed.netloc or parsed.path or "").strip().strip("/")
+    if not host:
+        return ""
+
+    return host.split("/")[0]
+
+
+def _parse_bool_env(name, default):
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _get_timeout():
+    raw = os.getenv("SCIHUB_TIMEOUT_SECONDS")
+    if not raw:
+        return DEFAULT_TIMEOUT_SECONDS
     try:
-        result = sh.fetch(doi)
-        return {
-            'doi': doi,
-            'pdf_url': result['url'],
-            'status': 'success',
-            'title': result.get('title', ''),
-            'author': result.get('author', ''),
-            'year': result.get('year', '')
+        timeout = float(raw)
+        if timeout <= 0:
+            raise ValueError("timeout must be positive")
+        return timeout
+    except ValueError:
+        LOGGER.warning("Invalid SCIHUB_TIMEOUT_SECONDS=%r. Falling back to %.1f", raw, DEFAULT_TIMEOUT_SECONDS)
+        return DEFAULT_TIMEOUT_SECONDS
+
+
+def _build_session():
+    client_name = _get_http_client_name()
+    if client_name == "curl_cffi":
+        session = curl_requests.Session(impersonate=os.getenv("SCIHUB_IMPERSONATE", "chrome124"))
+    else:
+        session = requests.Session()
+
+    session.headers.update(
+        {
+            "User-Agent": os.getenv("SCIHUB_USER_AGENT", DEFAULT_USER_AGENT),
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Referer": os.getenv("SCIHUB_REFERER", "https://sci-hub.ren/"),
         }
-    except Exception as e:
-        print(f"搜索出错: {str(e)}")
-        return {
-            'doi': doi,
-            'status': 'not_found'
-        }
+    )
 
-def search_paper_by_title(title):
-    """通过标题在 Sci-Hub 上搜索论文"""
-    # 由于 SciHub 包不支持 search 方法，我们改用 DOI 搜索
-    # 首先尝试从 CrossRef 获取 DOI
-    try:
-        url = f"https://api.crossref.org/works?query.title={title}&rows=1"
-        response = requests.get(url)
-        if response.status_code == 200:
-            data = response.json()
-            if data['message']['items']:
-                doi = data['message']['items'][0]['DOI']
-                return search_paper_by_doi(doi)
-    except Exception as e:
-        print(f"CrossRef 搜索出错: {str(e)}")
-    
-    return {
-        'title': title,
-        'status': 'not_found'
-    }
+    cookie_header = os.getenv("SCIHUB_COOKIE", "").strip()
+    if cookie_header:
+        session.headers["Cookie"] = cookie_header
 
-def search_papers_by_keyword(keyword, num_results=10):
-    """通过关键词搜索论文，返回元数据列表"""
-    # 使用 CrossRef API 进行搜索
-    papers = []
-    try:
-        url = f"https://api.crossref.org/works?query={keyword}&rows={num_results}"
-        response = requests.get(url)
-        if response.status_code == 200:
-            data = response.json()
-            for item in data['message']['items']:
-                doi = item.get('DOI')
-                if doi:
-                    result = search_paper_by_doi(doi)
-                    if result['status'] == 'success':
-                        papers.append(result)
-    except Exception as e:
-        print(f"搜索出错: {str(e)}")
-    
-    return papers
+    proxy = os.getenv("SCIHUB_PROXY", "").strip()
+    if proxy:
+        session.proxies = {"http": proxy, "https": proxy}
 
-def download_paper(pdf_url, output_path):
-    """下载论文 PDF"""
-    sh = SciHub()
+    return session
+
+
+def _sanitize_filename(name):
+    cleaned = re.sub(r"[^\w.\-]+", "_", name or "paper.pdf").strip("._")
+    if not cleaned:
+        cleaned = "paper.pdf"
+    if not cleaned.lower().endswith(".pdf"):
+        cleaned = f"{cleaned}.pdf"
+    return cleaned
+
+
+def _default_download_dir():
+    configured = os.getenv("SCIHUB_DOWNLOAD_DIR", "").strip()
+    if configured:
+        return os.path.abspath(os.path.expanduser(configured))
+    return os.path.join(os.path.expanduser("~"), "Downloads")
+
+
+def _looks_like_vm_path(path):
+    normalized = path.replace("\\", "/")
+    return normalized.startswith("/home/claude/") or normalized.startswith("/sessions/")
+
+
+def _prepare_output_path(output_path, pdf_url):
+    requested = (output_path or "").strip()
+    parsed = urlparse(pdf_url or "")
+    fallback_name = _sanitize_filename(os.path.basename(parsed.path) or "paper.pdf")
+
+    if not requested:
+        target = os.path.join(_default_download_dir(), fallback_name)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        return target
+
+    if _looks_like_vm_path(requested):
+        target = os.path.join(_default_download_dir(), _sanitize_filename(os.path.basename(requested)))
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        return target
+
+    target = os.path.abspath(os.path.expanduser(requested))
+    parent = os.path.dirname(target) or "."
     try:
-        sh.download(pdf_url, output_path)
+        os.makedirs(parent, exist_ok=True)
+        test_path = os.path.join(parent, f".__scihub_write_test_{os.getpid()}")
+        with open(test_path, "wb"):
+            pass
+        os.remove(test_path)
+        return target
+    except OSError:
+        fallback = os.path.join(_default_download_dir(), _sanitize_filename(os.path.basename(target) or fallback_name))
+        os.makedirs(os.path.dirname(fallback), exist_ok=True)
+        return fallback
+
+
+def _get_configured_mirrors():
+    """Build prioritized mirror list."""
+    primary = _normalize_mirror(os.getenv("SCIHUB_BASE_URL", DEFAULT_SCIHUB_BASE_URL))
+    if not primary:
+        primary = _normalize_mirror(DEFAULT_SCIHUB_BASE_URL)
+
+    mirrors = [primary]
+
+    extra_raw = os.getenv("SCIHUB_BASE_URLS", "")
+    for candidate in [item.strip() for item in extra_raw.split(",") if item.strip()]:
+        normalized = _normalize_mirror(candidate)
+        if normalized and normalized not in mirrors:
+            mirrors.append(normalized)
+
+    include_defaults = _parse_bool_env("SCIHUB_INCLUDE_DEFAULT_MIRRORS", False)
+    if include_defaults:
+        for candidate in SciHub().available_base_url_list:
+            if candidate not in mirrors:
+                mirrors.append(candidate)
+
+    return mirrors
+
+
+def _is_cloudflare_challenge(response):
+    text = response.text[:20000] if response.text else ""
+    if response.headers.get("cf-mitigated", "").lower() == "challenge":
         return True
-    except Exception as e:
-        print(f"下载出错: {str(e)}")
+    if response.status_code in {403, 429, 503} and (
+        "Just a moment..." in text
+        or "cf-browser-verification" in text
+        or "Attention Required!" in text
+        or "challenge-platform" in text
+    ):
+        return True
+    return False
+
+
+def _normalize_pdf_candidate(candidate, page_url):
+    if not candidate:
+        return ""
+    src = candidate.strip()
+    if src.startswith("//"):
+        src = f"https:{src}"
+    elif src.startswith("/"):
+        src = urljoin(page_url, src)
+    elif src.startswith("./") or src.startswith("../"):
+        src = urljoin(page_url, src)
+
+    if src.startswith("http://") or src.startswith("https://"):
+        return src
+    return ""
+
+
+def _extract_doi_from_url(value):
+    parsed = urlparse(value or "")
+    if not parsed.path:
+        return ""
+
+    path = unquote(parsed.path).strip("/")
+    if path.lower().startswith("pdf/"):
+        path = path[4:]
+    if path.lower().endswith(".pdf"):
+        path = path[:-4]
+
+    # Common DOI pattern with numeric prefix.
+    match = re.search(r"(10\.\d{4,9}/[-._;()/:A-Za-z0-9]+)", path)
+    if match:
+        return match.group(1)
+
+    # If path itself looks like DOI after stripping.
+    if path.startswith("10.") and "/" in path:
+        return path
+    return ""
+
+
+def _extract_pdf_url_from_html(html, page_url):
+    soup = BeautifulSoup(html or "", "html.parser")
+    candidates = []
+
+    tag_attr_pairs = [
+        ("iframe", "src"),
+        ("embed", "src"),
+        ("object", "data"),
+        ("meta", "content"),
+        ("a", "href"),
+    ]
+
+    for tag, attr in tag_attr_pairs:
+        for element in soup.find_all(tag):
+            if tag == "meta" and element.get("name", "").lower() != "citation_pdf_url":
+                continue
+            value = element.get(attr)
+            if value:
+                candidates.append(value)
+
+    # Fallback regex for direct PDF links in inline scripts/content.
+    for match in re.findall(r"https?://[^\\\"'\\s<>]+\\.pdf(?:\\?[^\\\"'\\s<>]*)?", html or "", re.IGNORECASE):
+        candidates.append(match)
+
+    for candidate in candidates:
+        normalized = _normalize_pdf_candidate(candidate, page_url)
+        if normalized:
+            return normalized
+
+    return ""
+
+
+def _is_probably_pdf_response(response):
+    content_type = (response.headers.get("content-type") or "").lower()
+    if "application/pdf" in content_type:
+        return True
+    if response.status_code >= 400:
         return False
 
+    try:
+        first_chunk = next(response.iter_content(chunk_size=16), b"")
+    except Exception:
+        return False
+    return first_chunk.startswith(b"%PDF")
 
-if __name__ == "__main__":
-    print("Sci-Hub 论文搜索测试\n")
 
-    # 1. DOI 搜索测试
-    print("1. 通过 DOI 搜索论文")
-    test_doi = "10.1002/jcad.12075"  # 一篇神经科学相关的论文
-    result = search_paper_by_doi(test_doi)
-    
-    if result['status'] == 'success':
-        print(f"标题: {result['title']}")
-        print(f"作者: {result['author']}")
-        print(f"年份: {result['year']}")
-        print(f"PDF URL: {result['pdf_url']}")
-        
-        # 尝试下载论文
-        output_file = f"paper_{test_doi.replace('/', '_')}.pdf"
-        if download_paper(result['pdf_url'], output_file):
-            print(f"论文已下载到: {output_file}")
-        else:
-            print("论文下载失败")
-    else:
-        print(f"未找到 DOI 为 {test_doi} 的论文")
+def _validate_pdf_candidate(session, pdf_url, timeout):
+    try:
+        response = session.get(pdf_url, timeout=timeout, verify=False, stream=True, allow_redirects=True)
+    except requests.exceptions.RequestException as exc:
+        return "", f"candidate_request_error:{type(exc).__name__}"
 
-    # 2. 标题搜索测试
-    print("\n2. 通过标题搜索论文")
-    test_title = "Choosing Assessment Instruments for Posttraumatic Stress Disorder Screening and Outcome Research"
-    result = search_paper_by_title(test_title)
-    
-    if result['status'] == 'success':
-        print(f"DOI: {result['doi']}")
-        print(f"作者: {result['author']}")
-        print(f"年份: {result['year']}")
-        print(f"PDF URL: {result['pdf_url']}")
-    else:
-        print(f"未找到标题为 '{test_title}' 的论文")
+    if _is_cloudflare_challenge(response):
+        return "", "candidate_cloudflare_challenge"
+    if _is_probably_pdf_response(response):
+        return pdf_url, "ok"
+    return "", f"candidate_not_pdf_status_{response.status_code}"
 
-    # 3. 关键词搜索测试
-    print("\n3. 通过关键词搜索论文")
-    test_keyword = "artificial intelligence medicine 2023"
-    papers = search_papers_by_keyword(test_keyword, num_results=3)
-    
-    for i, paper in enumerate(papers, 1):
-        print(f"\n论文 {i}:")
-        print(f"标题: {paper['title']}")
-        print(f"DOI: {paper['doi']}")
-        print(f"作者: {paper['author']}")
-        print(f"年份: {paper['year']}")
-        if paper.get('pdf_url'):
-            print(f"PDF URL: {paper['pdf_url']}")
 
+def _download_candidate_to_file(session, pdf_url, output_path, timeout):
+    response = session.get(pdf_url, timeout=timeout, verify=False, stream=True, allow_redirects=True)
+    if _is_cloudflare_challenge(response):
+        return False, "cloudflare_challenge"
+    if response.status_code >= 400:
+        return False, f"http_{response.status_code}"
+
+    first_chunk = b""
+    with open(output_path, "wb") as handle:
+        for chunk in response.iter_content(chunk_size=8192):
+            if not chunk:
+                continue
+            if not first_chunk:
+                first_chunk = chunk
+            handle.write(chunk)
+
+    if first_chunk and not first_chunk.startswith(b"%PDF"):
+        return False, "not_pdf_content"
+    return True, "ok"
+
+
+def _try_identifier_with_mirror(session, mirror_host, identifier, timeout):
+    endpoints = [
+        ("get", f"https://{mirror_host}/{identifier}", None),
+        ("post", f"https://{mirror_host}/", {"request": identifier}),
+    ]
+
+    last_reason = "no_response"
+    for method, url, payload in endpoints:
+        try:
+            if method == "get":
+                response = session.get(url, timeout=timeout, verify=False, allow_redirects=True)
+            else:
+                response = session.post(url, data=payload, timeout=timeout, verify=False, allow_redirects=True)
+        except requests.exceptions.RequestException as exc:
+            last_reason = f"request_error:{type(exc).__name__}"
+            continue
+
+        if _is_cloudflare_challenge(response):
+            last_reason = "cloudflare_challenge"
+            continue
+
+        content_type = (response.headers.get("content-type") or "").lower()
+        if "application/pdf" in content_type:
+            validated_url, reason = _validate_pdf_candidate(session, response.url, timeout)
+            if validated_url:
+                return validated_url, "ok"
+            last_reason = reason
+            continue
+
+        pdf_url = _extract_pdf_url_from_html(response.text, response.url)
+        if pdf_url:
+            validated_url, reason = _validate_pdf_candidate(session, pdf_url, timeout)
+            if validated_url:
+                return validated_url, "ok"
+            last_reason = reason
+            continue
+
+        last_reason = f"no_pdf_marker_status_{response.status_code}"
+
+    return "", last_reason
+
+
+def _resolve_pdf_url(identifier):
+    mirrors = _get_configured_mirrors()
+    timeout = _get_timeout()
+    session = _build_session()
+    errors = []
+
+    for mirror in mirrors:
+        pdf_url, reason = _try_identifier_with_mirror(session, mirror, identifier, timeout)
+        if pdf_url:
+            return pdf_url, mirror, errors
+        errors.append(f"{mirror}:{reason}")
+
+    return "", "", errors
+
+
+def _get_crossref_metadata(doi):
+    try:
+        response = requests.get(
+            f"https://api.crossref.org/works/{doi}",
+            timeout=15,
+            headers={"User-Agent": os.getenv("SCIHUB_USER_AGENT", DEFAULT_USER_AGENT)},
+        )
+        if response.status_code != 200:
+            return {}
+
+        payload = response.json().get("message", {})
+        title = ""
+        if payload.get("title"):
+            title = payload["title"][0]
+
+        year = ""
+        for field in ("published-print", "published-online", "issued"):
+            date_parts = payload.get(field, {}).get("date-parts", [])
+            if date_parts and date_parts[0]:
+                year = str(date_parts[0][0])
+                break
+
+        authors = []
+        for item in payload.get("author", []):
+            given = (item.get("given") or "").strip()
+            family = (item.get("family") or "").strip()
+            full = " ".join(part for part in [given, family] if part).strip()
+            if full:
+                authors.append(full)
+
+        return {
+            "title": title,
+            "author": ", ".join(authors),
+            "year": year,
+        }
+    except Exception as exc:
+        LOGGER.debug("CrossRef metadata lookup failed for DOI %s: %s", doi, exc)
+        return {}
+
+
+def create_scihub_instance():
+    """Create a SciHub instance with configured mirrors."""
+    sh = SciHub()
+    sh.timeout = int(max(_get_timeout(), 1))
+    sh.available_base_url_list = _get_configured_mirrors()
+    sh.current_base_url_index = 0
+    return sh
+
+
+def search_paper_by_doi(doi):
+    """Search Sci-Hub by DOI and return PDF URL + metadata if found."""
+    pdf_url, mirror, errors = _resolve_pdf_url(doi)
+    if not pdf_url:
+        error_msg = "; ".join(errors[:8]) if errors else "no_mirror_response"
+        return {
+            "doi": doi,
+            "status": "not_found",
+            "error": (
+                "Failed to resolve PDF URL from configured mirrors. "
+                f"Details: {error_msg}. "
+                "If mirrors return Cloudflare challenge pages, set SCIHUB_PROXY or SCIHUB_COOKIE."
+            ),
+        }
+
+    metadata = _get_crossref_metadata(doi)
+    return {
+        "doi": doi,
+        "pdf_url": pdf_url,
+        "status": "success",
+        "mirror": mirror,
+        "title": metadata.get("title", ""),
+        "author": metadata.get("author", ""),
+        "year": metadata.get("year", ""),
+    }
+
+
+def search_paper_by_title(title):
+    """Search by title via CrossRef DOI lookup then Sci-Hub DOI resolution."""
+    try:
+        response = requests.get(
+            f"https://api.crossref.org/works?query.title={title}&rows=1",
+            timeout=15,
+            headers={"User-Agent": os.getenv("SCIHUB_USER_AGENT", DEFAULT_USER_AGENT)},
+        )
+        if response.status_code == 200:
+            data = response.json()
+            items = data.get("message", {}).get("items", [])
+            if items:
+                doi = items[0].get("DOI")
+                if doi:
+                    return search_paper_by_doi(doi)
+    except Exception as exc:
+        LOGGER.debug("CrossRef title lookup failed for %r: %s", title, exc)
+
+    return {
+        "title": title,
+        "status": "not_found",
+    }
+
+
+def search_papers_by_keyword(keyword, num_results=10):
+    """Search keyword via CrossRef and resolve each DOI through Sci-Hub."""
+    papers = []
+    try:
+        fetch_rows = min(max(int(num_results) * 4, int(num_results), 20), 100)
+        response = requests.get(
+            f"https://api.crossref.org/works?query={keyword}&rows={fetch_rows}",
+            timeout=20,
+            headers={"User-Agent": os.getenv("SCIHUB_USER_AGENT", DEFAULT_USER_AGENT)},
+        )
+        if response.status_code == 200:
+            data = response.json()
+            for item in data.get("message", {}).get("items", []):
+                doi = item.get("DOI")
+                if not doi:
+                    continue
+                title = ""
+                if item.get("title"):
+                    title = item["title"][0]
+
+                year = ""
+                for field in ("published-print", "published-online", "issued"):
+                    date_parts = item.get(field, {}).get("date-parts", [])
+                    if date_parts and date_parts[0]:
+                        year = str(date_parts[0][0])
+                        break
+
+                authors = []
+                for author in item.get("author", []):
+                    given = (author.get("given") or "").strip()
+                    family = (author.get("family") or "").strip()
+                    full = " ".join(part for part in [given, family] if part).strip()
+                    if full:
+                        authors.append(full)
+
+                base = {
+                    "doi": doi,
+                    "title": title,
+                    "author": ", ".join(authors),
+                    "year": year,
+                    "status": "metadata_only",
+                }
+
+                resolved = search_paper_by_doi(doi)
+                if resolved.get("status") == "success":
+                    base.update(
+                        {
+                            "status": "success",
+                            "pdf_url": resolved.get("pdf_url", ""),
+                            "mirror": resolved.get("mirror", ""),
+                        }
+                    )
+                else:
+                    if resolved.get("error"):
+                        base["error"] = resolved["error"]
+
+                papers.append(base)
+                if len(papers) >= num_results:
+                    break
+    except Exception as exc:
+        LOGGER.debug("Keyword search failed for %r: %s", keyword, exc)
+
+    return papers
+
+
+def download_paper(pdf_url, output_path):
+    """Download PDF from resolved Sci-Hub PDF URL."""
+    session = _build_session()
+    timeout = _get_timeout()
+    resolved_output_path = _prepare_output_path(output_path, pdf_url)
+    candidates = []
+
+    if pdf_url:
+        candidates.append(pdf_url)
+        candidates.append(pdf_url.split("#", 1)[0])
+
+    doi = _extract_doi_from_url(pdf_url)
+    if doi:
+        refreshed = search_paper_by_doi(doi)
+        refreshed_url = refreshed.get("pdf_url", "")
+        if refreshed_url:
+            candidates.append(refreshed_url)
+            candidates.append(refreshed_url.split("#", 1)[0])
+
+    # If a non-PDF Sci-Hub page URL is provided, resolve from identifier/path.
+    parsed = urlparse(pdf_url or "")
+    if parsed.netloc and "sci-hub" in parsed.netloc.lower() and ".pdf" not in parsed.path.lower():
+        identifier = parsed.path.strip("/")
+        if identifier:
+            resolved, _mirror, _errors = _resolve_pdf_url(unquote(identifier))
+            if resolved:
+                candidates.append(resolved)
+                candidates.append(resolved.split("#", 1)[0])
+
+    # Deduplicate while preserving order.
+    deduped_candidates = []
+    for candidate in candidates:
+        normalized = (candidate or "").strip()
+        if not normalized:
+            continue
+        if normalized not in deduped_candidates:
+            deduped_candidates.append(normalized)
+
+    errors = []
+    try:
+        for candidate in deduped_candidates:
+            try:
+                ok, reason = _download_candidate_to_file(session, candidate, resolved_output_path, timeout)
+                if ok:
+                    return {"success": True, "path": resolved_output_path, "source_url": candidate}
+                errors.append(f"{candidate}:{reason}")
+            except Exception as exc:
+                errors.append(f"{candidate}:{type(exc).__name__}")
+    except Exception as exc:
+        errors.append(f"global:{type(exc).__name__}:{exc}")
+
+    # Last-resort path: return a rich error with diagnosis.
+    reason = "; ".join(errors[:6]) if errors else "no_candidate_urls"
+    return {
+        "success": False,
+        "path": resolved_output_path,
+        "error": (
+            "Unable to download PDF from available URLs. "
+            f"Details: {reason}. "
+            "If host access is restricted in your runtime, download the returned pdf_url from a machine that can reach it."
+        ),
+    }

--- a/sci_hub_server.py
+++ b/sci_hub_server.py
@@ -1,14 +1,72 @@
-from typing import Any, List, Dict, Optional, Union
+import argparse
 import asyncio
 import logging
-from mcp.server.fastmcp import FastMCP
-from sci_hub_search import search_paper_by_doi, search_paper_by_title, search_papers_by_keyword, download_paper
+import os
+from typing import Any, Dict, List
 
-# Setup logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+from mcp.server.fastmcp import FastMCP
+from sci_hub_search import download_paper, search_paper_by_doi, search_paper_by_title, search_papers_by_keyword
+
+def _read_log_level() -> int:
+    raw = os.getenv("MCP_LOG_LEVEL", "ERROR").upper()
+    return getattr(logging, raw, logging.ERROR)
+
+
+# Setup logging (stderr only; keep default quiet for stdio transport)
+logging.basicConfig(level=_read_log_level(), format='%(asctime)s - %(levelname)s - %(message)s')
+
+SUPPORTED_TRANSPORTS = ("stdio", "sse", "streamable-http")
+
+
+def _read_int_env(name: str, fallback: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return fallback
+    try:
+        return int(value)
+    except ValueError:
+        logging.warning("Invalid %s value %r. Falling back to %d.", name, value, fallback)
+        return fallback
+
+
+def _normalize_path(path: str, trailing_slash: bool = False) -> str:
+    normalized = path if path.startswith("/") else f"/{path}"
+    if trailing_slash and not normalized.endswith("/"):
+        return f"{normalized}/"
+    if not trailing_slash and normalized != "/" and normalized.endswith("/"):
+        return normalized.rstrip("/")
+    return normalized
+
+
+def _read_transport_env() -> str:
+    transport = os.getenv("MCP_TRANSPORT", "streamable-http").strip().lower()
+    if transport not in SUPPORTED_TRANSPORTS:
+        logging.warning(
+            "Invalid MCP_TRANSPORT value %r. Falling back to %s.",
+            transport,
+            "streamable-http",
+        )
+        return "streamable-http"
+    return transport
+
+
+DEFAULT_TRANSPORT = _read_transport_env()
+DEFAULT_HOST = os.getenv("MCP_HOST", "0.0.0.0")
+DEFAULT_PORT = _read_int_env("MCP_PORT", 8000)
+DEFAULT_SSE_PATH = _normalize_path(os.getenv("MCP_SSE_PATH", "/sse"))
+DEFAULT_MESSAGE_PATH = _normalize_path(os.getenv("MCP_MESSAGE_PATH", "/messages/"), trailing_slash=True)
+DEFAULT_STREAMABLE_HTTP_PATH = _normalize_path(os.getenv("MCP_STREAMABLE_HTTP_PATH", "/mcp"))
+DEFAULT_MOUNT_PATH = os.getenv("MCP_MOUNT_PATH") or None
 
 # Initialize FastMCP server
-mcp = FastMCP("scihub")
+mcp = FastMCP(
+    "scihub",
+    host=DEFAULT_HOST,
+    port=DEFAULT_PORT,
+    sse_path=DEFAULT_SSE_PATH,
+    message_path=DEFAULT_MESSAGE_PATH,
+    streamable_http_path=DEFAULT_STREAMABLE_HTTP_PATH,
+)
 
 @mcp.tool()
 async def search_scihub_by_doi(doi: str) -> Dict[str, Any]:
@@ -108,11 +166,20 @@ async def download_scihub_pdf(pdf_url: str, output_path: str) -> str:
              - Error message with exception details if an error occurred
     """
     try:
-        success = await asyncio.to_thread(download_paper, pdf_url, output_path)
-        if success:
+        result = await asyncio.to_thread(download_paper, pdf_url, output_path)
+        if isinstance(result, dict):
+            if result.get("success"):
+                resolved_path = result.get("path", output_path)
+                source_url = result.get("source_url", pdf_url)
+                return f"PDF successfully downloaded to {resolved_path} (source: {source_url})"
+            error = result.get("error", "unknown error")
+            resolved_path = result.get("path", output_path)
+            return f"Failed to download PDF to {resolved_path}. {error}"
+
+        # Backward compatibility with older boolean return shape.
+        if result:
             return f"PDF successfully downloaded to {output_path}"
-        else:
-            return f"Failed to download PDF to {output_path}"
+        return f"Failed to download PDF to {output_path}"
     except Exception as e:
         return f"An error occurred while downloading PDF: {str(e)}"
 
@@ -155,7 +222,62 @@ async def get_paper_metadata(doi: str) -> Dict[str, Any]:
     except Exception as e:
         return {"error": f"An error occurred while getting metadata: {str(e)}"}
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Sci-Hub MCP server")
+    parser.add_argument(
+        "--transport",
+        choices=SUPPORTED_TRANSPORTS,
+        default=DEFAULT_TRANSPORT,
+        help="MCP transport to run",
+    )
+    parser.add_argument("--host", default=DEFAULT_HOST, help="Bind host for network transports")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="Bind port for network transports")
+    parser.add_argument(
+        "--streamable-http-path",
+        default=DEFAULT_STREAMABLE_HTTP_PATH,
+        help="HTTP path used for streamable-http transport",
+    )
+    parser.add_argument("--sse-path", default=DEFAULT_SSE_PATH, help="HTTP path used for SSE transport")
+    parser.add_argument(
+        "--message-path",
+        default=DEFAULT_MESSAGE_PATH,
+        help="Message path used by SSE transport",
+    )
+    parser.add_argument(
+        "--mount-path",
+        default=DEFAULT_MOUNT_PATH,
+        help="Optional app mount path for SSE transport",
+    )
+    return parser.parse_args()
+
+
+def configure_server(args: argparse.Namespace) -> None:
+    mcp.settings.host = args.host
+    mcp.settings.port = args.port
+    mcp.settings.streamable_http_path = _normalize_path(args.streamable_http_path)
+    mcp.settings.sse_path = _normalize_path(args.sse_path)
+    mcp.settings.message_path = _normalize_path(args.message_path, trailing_slash=True)
+
+
+def main() -> None:
+    args = parse_args()
+    configure_server(args)
+
+    logging.info(
+        "Starting Sci-Hub MCP server transport=%s host=%s port=%d streamable_http_path=%s",
+        args.transport,
+        args.host,
+        args.port,
+        mcp.settings.streamable_http_path,
+    )
+    try:
+        if args.transport == "sse":
+            mcp.run(transport="sse", mount_path=args.mount_path)
+        else:
+            mcp.run(transport=args.transport)
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        logging.info("Sci-Hub MCP server stopped.")
+
+
 if __name__ == "__main__":
-    logging.info("Starting Sci-Hub MCP Server")
-    # Initialize and run the server
-    mcp.run(transport='stdio')
+    main()


### PR DESCRIPTION
## Summary
- make Sci-Hub mirror configurable (defaulting to `sci-hub.ren`) and add robust mirror/url handling
- improve search reliability with Cloudflare-aware HTTP client support (`curl_cffi`) and better fallback behavior
- fix keyword search to return metadata entries instead of empty results when PDF resolution fails
- harden PDF download with URL fallback retries and writable-path fallback for containerized Claude runtimes
- update MCP tool responses/docs for clearer status and path reporting